### PR TITLE
Feat/microsoft authentication

### DIFF
--- a/frontend/components/SignInButton.tsx
+++ b/frontend/components/SignInButton.tsx
@@ -1,0 +1,21 @@
+import { useMsal } from "@azure/msal-react";
+import { IPublicClientApplication } from "@azure/msal-browser";
+import { Button } from "@mui/material";
+import { loginRequest } from "../src/authConfig";
+
+function handleLogin(instance: IPublicClientApplication) {
+  instance.loginPopup(loginRequest).catch(e => {
+    console.error(e);
+  });
+}
+
+/**
+ * Renders a button which, when selected, will open a popup for login
+ */
+const SignInButton = () => {
+  const { instance } = useMsal();
+
+  return <Button onClick={() => handleLogin(instance)}>Sign in</Button>;
+};
+
+export default SignInButton;

--- a/frontend/components/SignOutButton.tsx
+++ b/frontend/components/SignOutButton.tsx
@@ -1,0 +1,17 @@
+import { IPublicClientApplication } from "@azure/msal-browser";
+import { useMsal } from "@azure/msal-react";
+import { Button } from "@mui/material";
+
+function handleLogout(instance: IPublicClientApplication) {
+  instance.logoutPopup().catch(e => {
+    console.error(e);
+  });
+}
+
+const SignOutButton = () => {
+  const { instance } = useMsal();
+
+  return <Button onClick={() => handleLogout(instance)}>Sign out</Button>;
+};
+
+export default SignOutButton;

--- a/frontend/hooks/useAccessToken.tsx
+++ b/frontend/hooks/useAccessToken.tsx
@@ -1,0 +1,30 @@
+import { AuthenticationResult } from "@azure/msal-browser";
+import { useMsal } from "@azure/msal-react";
+import { useEffect, useState } from "react";
+import { loginRequest } from "../src/authConfig";
+
+const useAccessToken = () => {
+  const { instance, accounts } = useMsal();
+  const account = accounts[0];
+  const [accessToken, setAccessToken] = useState<string>("");
+
+  useEffect(() => {
+    if (instance && account) {
+      instance
+        .acquireTokenSilent({ ...loginRequest, account })
+        .then(response => {
+          setAccessToken(response.accessToken);
+        })
+        .catch(e => {
+          console.log(e);
+          instance.acquireTokenPopup(loginRequest).then(response => {
+            setAccessToken(response.accessToken);
+          });
+        });
+    }
+  }, [account, instance]);
+
+  return accessToken;
+};
+
+export default useAccessToken;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@azure/msal-browser": "^2.22.1",
+        "@azure/msal-react": "^1.3.1",
         "@emotion/cache": "^11.7.1",
         "@emotion/react": "^11.8.2",
         "@emotion/server": "^11.4.0",
@@ -36,6 +38,40 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.22.1.tgz",
+      "integrity": "sha512-VYvdSHnOen1CDok01OhfQ2qNxsrY10WAKe6c2reIuwqqDDOkWwq1IDkieGHpDRjj4kGdPZ/dle4d7SlvNi9EJQ==",
+      "dependencies": {
+        "@azure/msal-common": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
+      "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
+      "dependencies": {
+        "debug": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-react": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-1.3.1.tgz",
+      "integrity": "sha512-pg6Zuy1nOTDce1+xGFuSkYt3uaV8higCqczbautmmf3fo0CBugn1AYtXF/W5c1HWTF0Gsx2IQ1q2vQfDEZJZvA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@azure/msal-browser": "^2.22.1",
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4098,6 +4134,28 @@
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }
+    },
+    "@azure/msal-browser": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.22.1.tgz",
+      "integrity": "sha512-VYvdSHnOen1CDok01OhfQ2qNxsrY10WAKe6c2reIuwqqDDOkWwq1IDkieGHpDRjj4kGdPZ/dle4d7SlvNi9EJQ==",
+      "requires": {
+        "@azure/msal-common": "^6.1.0"
+      }
+    },
+    "@azure/msal-common": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.1.0.tgz",
+      "integrity": "sha512-IGjAHttOgKDPQr0Qxx1NjABR635ZNuN7LHjxI0Y7SEA2thcaRGTccy+oaXTFabM/rZLt4F2VrPKUX4BnR9hW9g==",
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
+    "@azure/msal-react": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-1.3.1.tgz",
+      "integrity": "sha512-pg6Zuy1nOTDce1+xGFuSkYt3uaV8higCqczbautmmf3fo0CBugn1AYtXF/W5c1HWTF0Gsx2IQ1q2vQfDEZJZvA==",
+      "requires": {}
     },
     "@babel/code-frame": {
       "version": "7.16.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@azure/msal-browser": "^2.22.1",
+    "@azure/msal-react": "^1.3.1",
     "@emotion/cache": "^11.7.1",
     "@emotion/react": "^11.8.2",
     "@emotion/server": "^11.4.0",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -5,6 +5,9 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { CacheProvider, EmotionCache } from "@emotion/react";
 import theme from "../src/theme";
 import createEmotionCache from "../src/createEmotionCache";
+import { PublicClientApplication } from "@azure/msal-browser";
+import { MsalProvider } from "@azure/msal-react";
+import { msalConfig } from "../src/authConfig";
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
@@ -12,8 +15,8 @@ const clientSideEmotionCache = createEmotionCache();
 interface MyAppProps extends AppProps {
   emotionCache?: EmotionCache;
 }
-
 export default function MyApp(props: MyAppProps) {
+  const msalInstance = new PublicClientApplication(msalConfig);
   const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
   return (
     <CacheProvider value={emotionCache}>
@@ -23,7 +26,9 @@ export default function MyApp(props: MyAppProps) {
       <ThemeProvider theme={theme}>
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
         <CssBaseline />
-        <Component {...pageProps} />
+        <MsalProvider instance={msalInstance}>
+          <Component {...pageProps} />
+        </MsalProvider>
       </ThemeProvider>
     </CacheProvider>
   );

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,9 +1,21 @@
-import { Grid, Typography, Container } from "@mui/material";
+import { Container } from "@mui/material";
 import type { NextPage } from "next";
 import Head from "next/head";
-import Image from "next/image";
+import { useIsAuthenticated, useMsal } from "@azure/msal-react";
+import dynamic from "next/dynamic";
+
+const SignInButton = dynamic(() => import("../components/SignInButton"), {
+  ssr: false,
+});
+const SignOutButton = dynamic(() => import("../components/SignOutButton"), {
+  ssr: false,
+});
 
 const Home: NextPage = () => {
+  const isAuthenticated = useIsAuthenticated();
+  const [account] = useMsal().accounts;
+  console.log(isAuthenticated);
+  console.log(account);
   return (
     <>
       <Head>
@@ -14,9 +26,7 @@ const Home: NextPage = () => {
 
       <main>
         <Container>
-          <Grid>
-            <Typography>Hello World</Typography>
-          </Grid>
+          {isAuthenticated ? <SignOutButton /> : <SignInButton />}
         </Container>
       </main>
     </>

--- a/frontend/src/authConfig.ts
+++ b/frontend/src/authConfig.ts
@@ -1,0 +1,21 @@
+export const msalConfig = {
+  auth: {
+    clientId: process.env.NEXT_PUBLIC_MICROSOFT_CLIENT_ID!,
+    authority: `https://login.microsoftonline.com/${process.env.NEXT_PUBLIC_MICROSOFT_TENANT_ID}`, // This is a URL (e.g. https://login.microsoftonline.com/{your tenant ID})
+    redirectUri: process.env.NEXT_PUBLIC_MICROSOFT_REDIRECT!,
+  },
+  cache: {
+    cacheLocation: "sessionStorage", // This configures where your cache will be stored
+    storeAuthStateInCookie: false, // Set this to "true" if you are having issues on IE11 or Edge
+  },
+};
+
+// Add scopes here for ID token to be used at Microsoft identity platform endpoints.
+export const loginRequest = {
+  scopes: ["User.Read"],
+};
+
+// Add the endpoints here for Microsoft Graph API services you'd like to use.
+// export const graphConfig = {
+//   graphMeEndpoint: "Enter_the_Graph_Endpoint_Here/v1.0/me",
+// };


### PR DESCRIPTION
### Changelog

- Add `SignInButton` and `SignOutButton` component
- Configure to log in with `Microsoft` account (only **@rmit.edu.vn**)
- Create `useAccessToken` custom hook to gain access token for future use

### How to test

- `checkout` this branch
- Run `npm install`
- Copy `.env.local` from **Team** to folder frontend
- Run `npm run dev`

### Expected result

- Ensure that only account with `@rmit.edu.vn` can log in
- Check console to see `account` return from `Microsoft`

close #2 